### PR TITLE
docs: fix successful spelling in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ Go to the [releases section](https://github.com/julienkay/MobileNeRF-Unity-Viewe
 
 ### Importing sample scenes
 
-After succesful installation, you can use the menu `MobileNeRF -> Asset Downloads` to download any of the sample scenes available.
+After successful installation, you can use the menu `MobileNeRF -> Asset Downloads` to download any of the sample scenes available.
 In each scene folder there will be a convenient prefab, that you can then drag into the scene and you're good to go.
 
 ### Updating


### PR DESCRIPTION
Changes:
- `succesful` -> `successful` in `readme.md` (1 occurrence(s))

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
